### PR TITLE
Fix unichr function on PHP 7.4

### DIFF
--- a/components/tcpdf/include/tcpdf_fonts.php
+++ b/components/tcpdf/include/tcpdf_fonts.php
@@ -1491,25 +1491,26 @@ class TCPDF_FONTS {
 	 * @public static
 	 */
 	public static function unichr($c, $unicode=true) {
-	    if(is_numeric($c)) {
-	        if (!$unicode) {
-	            return chr($c);
-	        } elseif ($c <= 0x7F) {
-	            // one byte
-	            return chr($c);
-	        } elseif ($c <= 0x7FF) {
-	            // two bytes
-	            return chr(0xC0 | $c >> 6).chr(0x80 | $c & 0x3F);
-	        } elseif ($c <= 0xFFFF) {
-	            // three bytes
-	            return chr(0xE0 | $c >> 12).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
-	        } elseif ($c <= 0x10FFFF) {
-	            // four bytes
-	            return chr(0xF0 | $c >> 18).chr(0x80 | $c >> 12 & 0x3F).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
-	        } else {
-	            return '';
-	        }
-	    }
+		if(!is_numeric($c)) {
+		    $c = hexdec($c);
+		}
+		if (!$unicode) {
+		    return chr($c);
+		} elseif ($c <= 0x7F) {
+		    // one byte
+		    return chr($c);
+		} elseif ($c <= 0x7FF) {
+		    // two bytes
+		    return chr(0xC0 | $c >> 6).chr(0x80 | $c & 0x3F);
+		} elseif ($c <= 0xFFFF) {
+		    // three bytes
+		    return chr(0xE0 | $c >> 12).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
+		} elseif ($c <= 0x10FFFF) {
+		    // four bytes
+		    return chr(0xF0 | $c >> 18).chr(0x80 | $c >> 12 & 0x3F).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
+		} else {
+		    return '';
+		}
 	}
 
 	/**

--- a/components/tcpdf/include/tcpdf_fonts.php
+++ b/components/tcpdf/include/tcpdf_fonts.php
@@ -1491,23 +1491,25 @@ class TCPDF_FONTS {
 	 * @public static
 	 */
 	public static function unichr($c, $unicode=true) {
-		if (!$unicode) {
-			return chr($c);
-		} elseif ($c <= 0x7F) {
-			// one byte
-			return chr($c);
-		} elseif ($c <= 0x7FF) {
-			// two bytes
-			return chr(0xC0 | $c >> 6).chr(0x80 | $c & 0x3F);
-		} elseif ($c <= 0xFFFF) {
-			// three bytes
-			return chr(0xE0 | $c >> 12).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
-		} elseif ($c <= 0x10FFFF) {
-			// four bytes
-			return chr(0xF0 | $c >> 18).chr(0x80 | $c >> 12 & 0x3F).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
-		} else {
-			return '';
-		}
+	    if(is_numeric($c)) {
+	        if (!$unicode) {
+	            return chr($c);
+	        } elseif ($c <= 0x7F) {
+	            // one byte
+	            return chr($c);
+	        } elseif ($c <= 0x7FF) {
+	            // two bytes
+	            return chr(0xC0 | $c >> 6).chr(0x80 | $c & 0x3F);
+	        } elseif ($c <= 0xFFFF) {
+	            // three bytes
+	            return chr(0xE0 | $c >> 12).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
+	        } elseif ($c <= 0x10FFFF) {
+	            // four bytes
+	            return chr(0xF0 | $c >> 18).chr(0x80 | $c >> 12 & 0x3F).chr(0x80 | $c >> 6 & 0x3F).chr(0x80 | $c & 0x3F);
+	        } else {
+	            return '';
+	        }
+	    }
 	}
 
 	/**


### PR DESCRIPTION
This fixes the error "chr() expects parameter 1 to be int, string given" on PHP 7.4.